### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,48 @@
+# AGENTS.md
+
+## Project purpose
+
+Tiny C daemon that listens on a UDP broadcast port and re-emits packets onto other interfaces preserving the original sender. Used on VyOS to relay LAN-discovery broadcasts (game LAN, DHCP-style flows) across interfaces, including ppp links. Ships as the `udp-broadcast-relay` Debian package with a `udp-broadcast-relay@.service` systemd unit.
+
+## Tech stack
+
+- Plain C. Single source file (`udp-broadcast-relay.c`).
+- `Makefile` (no autotools). Debian packaging in `debian/`.
+- License: GPL-2.0.
+
+## Build / test / run
+
+```sh
+make                       # gcc -O0 udp-broadcast-relay.c -o udp-broadcast-relay
+dpkg-buildpackage -us -uc  # produces udp-broadcast-relay.deb
+```
+
+Runtime: `systemctl start udp-broadcast-relay@<id>.service` after configuring `/etc/default/udp-broadcast-relay`. PPP integration via `ppp-if.up-local`.
+
+## Repository layout
+
+- `udp-broadcast-relay.c` — daemon source.
+- `udp-broadcast-relay.8` — man page.
+- `udp-broadcast-relay.default`, `udp-broadcast-relay@.service`, `ppp-if.up-local` — configuration / integration files.
+- `Makefile`, `debian/`.
+- `README.md` — install/usage/example documentation.
+- `COPYING` — GPL-2.0 license text.
+
+## Cross-repo context
+
+Listed in `VyOS-Networks/vyos-build-packages/repos.toml` — pulled into the ISO via `vyos/vyos-build`. Configured at runtime by `vyos-1x` op-mode/conf-mode scripts (e.g. `service broadcast-relay`).
+
+## Conventions
+
+- Default branch `current`. Active workflows: `cla-check.yml`, `trigger-rebuild-repo-package.yml` — wired into the rebuild-dispatch chain.
+- Commit / PR title format: `component: T12345: description` (Phorge task ID at https://vyos.dev).
+- Keep diffs against `nomeata/udp-broadcast-relay` minimal; the upstream branch is tracked as `upstream/master`.
+
+## Mirror relationship
+
+Mirror twin: `VyOS-Networks/udp-broadcast-relay`. Canonical side is here. Mirror pipeline is **not** wired up (no `pr-mirror-repo-sync.yml` workflow); cross-org sync handled manually if needed. The VyOS-Networks twin's default branch is the experimental `git-actions` (per relations doc §8.2) — ignore that side for canonical state.
+
+## Notes for future contributors
+
+- `Makefile` builds with `-O0` deliberately for debuggability; if you change CFLAGS, check the Debian package still passes lintian.
+- Single file means changes touch the whole daemon; coordinate with `vyos-1x` if the CLI surface changes.


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
